### PR TITLE
Remove allow_failures from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ env:
   - GHC_VERSION=7.8.4  CABAL_VERSION=1.20
   - GHC_VERSION=7.10.1 CABAL_VERSION=1.22
 
-matrix:
-  allow_failures:
-    - env: GHC_VERSION=7.10.1 CABAL_VERSION=1.22        
-
 before_install:
   - sudo add-apt-repository -y ppa:hvr/ghc
   - sudo apt-get update


### PR DESCRIPTION
All project dependencies has been fixed to work with GHC 7.10 we no longer need this
